### PR TITLE
close #16 @@@CODE fails due to missing encoding

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -1521,6 +1521,10 @@ def insert_code_from_file(filestr, format):
                 codelines = []
                 copy = False
                 for line_no, codeline in enumerate(codefile_lines):
+                    try:
+                        codeline = codeline.decode(encoding or 'utf-8')
+                    except (UnicodeDecodeError, AttributeError):
+                        pass
                     mf = cfrom.search(codeline)
                     if mf and fromto == 'fromto:' and not from_found:
                         # The test on not to_found ensures that


### PR DESCRIPTION
Enforced decoding with `codeline = codeline.decode(encoding or 'utf-8')`, where the `encoding` variable can be the value set with the `--encoding` option