### PR TITLE
Fix compilation of the manual

### DIFF
--- a/doc/src/manual/make.sh
+++ b/doc/src/manual/make.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -x
-
+#export PS4='+ l.${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 # NOTE: There are many doconce errors arising when compiling this manual
 # because it describes doconce syntax in the text, and this syntax is
 # not in the right context for all the syntax checks in doconce.
@@ -56,6 +56,9 @@ system doconce split_tmp.html manual.html
 system doconce format sphinx manual.do.txt --no_mako --cite_doconce --no_abort
 # We have several examples on AUTHOR: so to avoid multiple
 # authors we have to specify
+# Problem reproducible after: `git clean -fd && rm -rf sphinx-testdoc`
+#Hack: because doconce sphinx_dir ony works the second time (after an error), trigger that error by creating a bogus conf.py in ./
+touch conf.py 
 system doconce sphinx_dir theme=bootstrap version=1.0 intersphinx manual.do.txt
 cp manual.rst manual.sphinx.rst
 python automake_sphinx.py

--- a/doc/src/manual/manual.do.txt
+++ b/doc/src/manual/manual.do.txt
@@ -1102,7 +1102,7 @@ DocOnce starts translating the document. Such comments are very valuable
 as they will never interfere with the output format and they are only
 present in the DocOnce source. Mako has two types of comments:
 lines starting with a double hash `##` and multiple lines enclosed by
-the `<%doc>` (beginning) and `<%doc/>` (closing) tags.
+the `<%doc>` (beginning) and `</%doc>` (closing) tags.
 
 If you need a lot of comments in the DocOnce file, consider using
 Mako comments instead of the single hash, unless you want the
@@ -5489,7 +5489,7 @@ is
 a
 block
 comment in Mako.
-<%doc/>
+</%doc>
 !ec
 
 ===== Debugging Python code in Mako =====

--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -5205,7 +5205,7 @@ On Debian (incl. Ubuntu) systems, you can alternatively do
                             strict_undefined=strict_undefined)
         except Exception as e:
             errwarn('*** mako error: ' + str(type(e)).split("'")[1])
-            errwarn('   ' + str(e))
+            errwarn('    ' + str(e))
             if isinstance(e, mako.exceptions.SyntaxException):
                 import platform
                 errwarn('This could indicate that the mako template code is not compatible with the version of Python currently used by DocOnce and mako, which is Python %s' % platform.python_version())


### PR DESCRIPTION
The `doconce sphinx_dir` command in `doc/src/manual/make.sh` was still failing the first time it is run (or after a `git clean -fd`). This problem also used to happen in the tests where it could be solved with a "hack". The hack consists in creating an empty conf.py file before the `doconce sphinx_dir` command. I did the same in `doc/src/manual/make.sh` and recompiled the manual.

In addition, I corrected two typos in the manual (the Mako syntax for comments requires `</%doc>`, not `<%doc/>`).