### PR TITLE
No dot after admonition title in html format

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -70,8 +70,6 @@ from .misc import option, which, _abort
 from . import html, latex, pdflatex, rst, sphinx, st, epytext, gwiki, mwiki, cwiki, pandoc, ipynb, matlabnb
 from . import plaintext as plain
 
-admons = 'notice', 'summary', 'warning', 'question', 'block'
-
 main_content_begin = globals.main_content_char*19 + ' main content ' + \
                      globals.main_content_char*22
 main_content_end = globals.main_content_char*19 + ' end of main content ' + \
@@ -2566,7 +2564,7 @@ def typeset_envirs(filestr, format):
                 # Just indent the block
                 def subst(m):
                     return indent_lines(m.group(1), format, ' '*4) + '\n'
-            elif envir in admons + ('hint', 'remarks'):
+            elif envir in globals.admons + ('hint', 'remarks'):
                 # Just a plain paragraph with paragraph heading
                 def subst(m):
                     title = m.group(1).strip()

--- a/lib/doconce/globals.py
+++ b/lib/doconce/globals.py
@@ -43,6 +43,9 @@ style = {
 inline_tag_begin = r"""(?P<begin>(^|[(\s~>{!-]|^__|&[mn]dash;))"""
 inline_tag_end = r"""(?P<end>($|[.,?!;:)<}!'\s~\[<&;-]))"""
 
+# Admonitions
+admons = 'notice', 'summary', 'warning', 'question', 'block'
+
 # Support for non-English languages (not really implemented yet)
 locale_dict = dict(
     language='English',  # language to be used

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -2571,7 +2571,6 @@ def html_quote(block, format, text_size='normal'):
 </blockquote>
 """ % (indent_lines(block, format, ' '*4, trailing_newline=False))
 
-admons = 'notice', 'summary', 'warning', 'question', 'block'
 global admon_css_vars        # set in define
 global html_admon_style      # set below
 
@@ -2589,7 +2588,7 @@ if html_admon_style is None:
     else:
         html_admon_style = 'gray'
 
-for _admon in admons:
+for _admon in globals.admons:
     # _Admon is constructed at import time, used as default title, but
     # will always be in English because of the early construction
     _Admon = globals.locale_dict[globals.locale_dict['language']].get(_admon, _admon).capitalize()  # upper first char
@@ -2605,11 +2604,6 @@ def html_%(_admon)s(block, format, title='%(_Admon)s', text_size='normal'):
     # Blocks without explicit title should have empty title
     if title == 'Block':  # block admon has no default title
         title = ''
-
-    if title and (title[-1] not in ('.', ':', '!', '?')) and \
-       html_admon_style != 'bootstrap_panel':
-        # Make sure the title ends with puncuation
-        title += '.'
 
     # Make pygments background equal to admon background for colored admons?
     keep_pygm_bg = option('keep_pygments_html_bg')
@@ -2967,7 +2961,7 @@ def define(FILENAME_EXTENSION,
         for tp in ('yellow', 'apricot', 'gray'):
             admon_css_vars[tp]['boundary'] = html_admon_bd_color
 
-    for a in admons:
+    for a in globals.admons:
         if a != 'block':
             admon_css_vars['yellow']['icon_' + a]  = 'small_yellow_%s.png' % a
             admon_css_vars['apricot']['icon_' + a] = 'small_yellow_%s.png' % a
@@ -3001,7 +2995,7 @@ def define(FILENAME_EXTENSION,
             admon_styles2)
 
     # Need to add admon_styles? (html_admon_style is global)
-    for admon in admons:
+    for admon in globals.admons:
         if '!b'+admon in filestr and '!e'+admon in filestr:
             if html_admon_style == 'colors':
                 css += (admon_styles1 % admon_css_vars[html_admon_style])

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -542,9 +542,8 @@ def latex_code(filestr, code_blocks, code_block_types,
             admon_envir_mapping = dict([pair.split('-') for pair in code_envir_transform.split(',')])
     lines = filestr.splitlines()
     inside_admon = False
-    admons = 'notice', 'summary', 'warning', 'question', 'block'
     for i in range(len(lines)):
-        for admon in admons:
+        for admon in globals.admons:
             if lines[i].startswith('!b' + admon):
                 inside_admon = True
             if lines[i].startswith('!e' + admon):
@@ -636,9 +635,8 @@ def latex_code(filestr, code_blocks, code_block_types,
         # to be block envirs.)
 
         # Generate admon automatically name by name
-        admons = 'notice', 'summary', 'warning', 'question', 'block'
-        #Admons = [admon[0].upper() + admon[1:] for admon in admons]
-        for admon in admons:
+        #Admons = [admon[0].upper() + admon[1:] for admon in globals.admons]
+        for admon in globals.admons:
             # First admons without title
             pattern = r'!b%s *\n' % admon
             filestr = re.sub(pattern, r'\\begin{block}{%s}\n' %
@@ -2340,8 +2338,7 @@ def get_admon_figname(admon_tp, admon_name):
             return None
 
 # Generate Python functions for admons
-admons = 'notice', 'summary', 'warning', 'question', 'block'
-for _admon in admons:
+for _admon in globals.admons:
     _Admon = globals.locale_dict[globals.locale_dict['language']].get(_admon, _admon).capitalize()
     _title_period = '' if option('latex_admon_title_no_period') else '.'
     text = r"""
@@ -3719,7 +3716,7 @@ justified,
 
 
     # Admonitions
-    if re.search(r'^!b(%s)' % '|'.join(admons), filestr, flags=re.MULTILINE):
+    if re.search(r'^!b(%s)' % '|'.join(globals.admons), filestr, flags=re.MULTILINE):
         # Found one !b... command for an admonition
 
         # default colors
@@ -3745,7 +3742,7 @@ justified,
         # Multiple admon colors specified?
         multiple_colors = False
         if latex_admon_color is not None:
-            for a in admons:
+            for a in globals.admons:
                 if a+':' in latex_admon_color:
                     multiple_colors = True
                     break
@@ -3764,9 +3761,9 @@ justified,
                     errwarn('    ' + latex_admon_color)
                     errwarn('    split wrt ; and : ' + latex_admon_colors)
                     _abort()
-            admons_found = {a: False for a in admons}
+            admons_found = {a: False for a in globals.admons}
             for a, c in latex_admon_colors:
-                if a not in admons:
+                if a not in globals.admons:
                     errwarn('*** error: wrong syntax in --latex_admon_color=%s' % latex_admon_color)
                     errwarn('    %s is not an admonition name' % a)
                     _abort()
@@ -3774,7 +3771,7 @@ justified,
             for a in admons_found:
                 if not a:
                     errwarn('*** error in --latex_admon_color syntax: all admon types must be specified!')
-                    errwarn('    ' + ', '.join(admons))
+                    errwarn('    ' + ', '.join(globals.admons))
                     errwarn('    missing ' + a)
                     _abort()
             try:
@@ -3785,10 +3782,10 @@ justified,
         elif latex_admon_color is not None and \
              not latex_admon_color.endswith('style'):
             try:
-                latex_admon_colors = [[a, eval(latex_admon_color)] for a in admons]
+                latex_admon_colors = [[a, eval(latex_admon_color)] for a in globals.admons]
             except SyntaxError:
                 # eval(latex_admon_color) did not work, treat it as valid color
-                latex_admon_colors = [[a, latex_admon_color] for a in admons]
+                latex_admon_colors = [[a, latex_admon_color] for a in globals.admons]
         admon_styles = 'colors1', 'colors2', 'mdfbox', 'graybox2', 'grayicon', 'yellowicon', 'tcb', 'vbar'
         admon_color = {style: {} for style in admon_styles}
 
@@ -3807,7 +3804,7 @@ justified,
                     #block=_gray2,
                     block=yellow1,
                     )
-            for admon in admons:
+            for admon in globals.admons:
                 admon_color['mdfbox'][admon] = gray1
                 admon_color['graybox2'][admon] = gray2
                 admon_color['grayicon'][admon] = gray3
@@ -3871,7 +3868,7 @@ justified,
         INTRO['latex'] += '\n' + packages + '\n\n% --- begin definitions of admonition environments ---\n'
 
         for style in admon_styles:
-            for admon in admons:
+            for admon in globals.admons:
                 color = admon_color[style][admon]
                 if isinstance(color, (tuple,list)):
                     rgb = ','.join([str(cl) for cl in color])
@@ -3945,7 +3942,7 @@ justified,
         #"""
 
         # Define environments depending on the admon type
-        for admon in admons:
+        for admon in globals.admons:
             Admon = admon.upper()[0] + admon[1:]
 
             # Figure files are copied when necessary

--- a/test/_testdoc.do.txt
+++ b/test/_testdoc.do.txt
@@ -1594,7 +1594,7 @@ and this one as Project ref{exer:you}.
 
 ======= References =======
 
-BIBFILE: papers.pub
+#BIBFILE: papers.pub
 
 
 ======= Appendix: Just for testing; part I =======


### PR DESCRIPTION
Admonitions (`notice, summary, warning, question, block`) add a dot after their title when compiled in html format. This is not necessary