### PR TITLE
Fixing pandoc.py for python 3 line 210 and line 211, re.sub

### DIFF
--- a/lib/doconce/pandoc.py
+++ b/lib/doconce/pandoc.py
@@ -207,8 +207,8 @@ def pandoc_code(filestr, code_blocks, code_block_types,
     # \eqref and labels will not work, but labels do no harm
     filestr = filestr.replace(' label{', ' \\label{')
     pattern = r'^label\{'
-    filestr = re.sub(pattern, '\\label{', filestr, flags=re.MULTILINE)
-    filestr = re.sub(r'\(ref\{(.+?)\}\)', r'\eqref{\g<1>}', filestr)
+    filestr = re.sub(pattern, '\\\\label{', filestr, flags=re.MULTILINE)
+    filestr = re.sub(r'\\(ref\\{(.+?)\\}\\)', r'\\eqref{\g<1>}', filestr)
 
     # Final fixes
 
@@ -220,7 +220,7 @@ def pandoc_code(filestr, code_blocks, code_block_types,
     #   - [ ] task 2 not yet done
     if github_md:
         pattern = '^(\s+)\*\s+(\[[x ]\])\s+'
-        filestr = re.sub(pattern, '\g<1>- \g<2> ', filestr, flags=re.MULTILINE)
+        filestr = re.sub(pattern, '\\g<1>- \\g<2> ', filestr, flags=re.MULTILINE)
 
     return filestr
 
@@ -230,7 +230,7 @@ def pandoc_table(table):
         # Fix the problem that `verbatim` inside the table is not
         # typeset as verbatim (according to the pandoc translator rules)
         # in the GitHub Issue Tracker
-        text = re.sub(r'`([^`]+?)`', '<code>\g<1></code>', text)
+        text = re.sub(r'`([^`]+?)`', '<code>\\g<1></code>', text)
         return text
 
     # else: Pandoc-extended Markdown syntax


### PR DESCRIPTION
Copy of [this commit](https://github.com/hplgit/doconce/commit/d6a9a40b8f8b4ba583c78a68e3fbf4d147ad90d9) in hplgit/doconce pushed by [mimeiners](https://github.com/mimeiners).
The author corrected four re.sub expressions in `pandoc.py`