### PR TITLE
Add compatibility with ipython notebook version 5.

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -590,7 +590,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             errwarn('*** error: could not import IPython.nbformat.v3!')
             errwarn('    set --ipynb_version=4 or leave out --ipynb_version=3')
             _abort()
-    elif nb_version == 4:
+    elif nb_version in (4, 5):
         try:
             from nbformat.v4 import (
                 new_code_cell, new_markdown_cell, new_notebook)


### PR DESCRIPTION
Trying to compile doconce/doc/src/admon/make.sh caused error related to ipython.

`> [...]/site-packages/IPython/nbformat.py:12: ShimWarning: The `IPython.nbformat` package has been deprecated since IPython 4.0. You should import from nbformat instead.
>   warn("The `IPython.nbformat` package has been deprecated since IPython 4.0. "
> *** error: cannot do import nbformat.v4 or IPython.nbformat.v4
>     make sure IPython notebook or Jupyter is installed correctly
> Abort! (add --no_abort on the command line to avoid this abortion)`

I was able to fix this by simply changing the version check from only looking for `4` to also looking for `5`:
`elif nb_version == 4`

was changed to

`elif nb_version in (4, 5)`

I was subsequently able to compile the ipython part of admon/bash.sh (there are still issues with the sphinx part of the file, but I will look into those later).