### PR TITLE
Allow escaping references and labels to avoid compilation issues in the documentation

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -4748,6 +4748,12 @@ def doconce2format(filestr_in, format):
     # newcommands files are inserted)
     filestr = bm2boldsymbol(filestr, format)
 
+    # Allow escaping of labels and references, which useful in e.g. the DocOnce
+    # manual where labels or references are inside code examples (the !bc !ec commands)
+    if 'label\{' in filestr or 'ref\{' in filestr:
+        filestr = filestr.replace('label\{', 'label{')
+        filestr = filestr.replace('ref\{', 'ref{')
+
     # Next step: replace environments starting with | (instead of !)
     # by ! (for illustration of doconce syntax inside !bc/!ec directives).
     # Enough to consider |bc, |ec, |bt, and |et since all other environments


### PR DESCRIPTION
The documentation shows same DocOnce code. Sample code is contained within the `!bc ... !ec`commands. However, labels and references in the code may cause error when compiled, for example: 

```
*** error: found duplicate labels:
    %s theorem:fundamental1 doconce:manual:exercise:ex
```
Now a user can use this syntax for labels and references: **`label\{mylabel}`** and **`ref\{mylabel}`**. This syntax will avoid triggering an error from the syntax check, but will be converted to `label{mylabel}` and `ref{mylabel}` after that and get rendered as usual in the output document. 

```
label{a_normal_label}

DocOnce documentation: you can create a label as follows
!bc
label\{theorem:fundamental1}
!ec
```

This enhancement will probably be needed only for the DocOnce documentation.