### PR TITLE
Updated .ipynb support

### DIFF
--- a/doc/src/manual/install_doconce.py
+++ b/doc/src/manual/install_doconce.py
@@ -61,13 +61,12 @@ system('sudo apt-get -y install python-setuptools')
 system('pip install setuptools')
 system('sudo apt-get -y install python-pdftools')
 system('pip install ipython')
+system('pip install jupyter')
 system('pip install tornado')
 system('pip install pyzmq')
 system('pip install traitlets')
 system('pip install pickleshare')
 system('pip install jsonschema')
-# If problems with IPython.nbformat.v4: clone ipython and run setup.py
-# to get the latest version
 
 # Preprocessors
 system('pip install future')

--- a/doc/src/manual/install_doconce.sh
+++ b/doc/src/manual/install_doconce.sh
@@ -55,13 +55,12 @@ apt_install python-setuptools
 pip_install setuptools
 apt_install python-pdftools
 pip_install ipython
+pip_install jupyter
 pip_install tornado
 pip_install pyzmq
 pip_install traitlets
 pip_install pickleshare
 pip_install jsonschema
-# If problems with IPython.nbformat.v4: clone ipython and run setup.py
-# to get the latest version
 
 # Preprocessors
 pip_install future

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -611,7 +611,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
         if (block_tp == 'text' or block_tp == 'math') and block != '' and block != '<!--  -->':
             if nb_version == 3:
                 nb.cells.append(new_text_cell(u'markdown', source=block))
-            elif nb_version == 4:
+            elif nb_version in (4, 5):
                 cells.append(new_markdown_cell(source=block))
             mdstr.append(('markdown', block))
         elif block_tp == 'cell' and block != '' and block != []:
@@ -624,7 +624,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
                                 input=block_,
                                 prompt_number=prompt_number,
                                 collapsed=False))
-                        elif nb_version == 4:
+                        elif nb_version in (4, 5):
                             cells.append(new_code_cell(
                                 source=block_,
                                 execution_count=prompt_number,
@@ -639,7 +639,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
                             input=block,
                             prompt_number=prompt_number,
                             collapsed=False))
-                    elif nb_version == 4:
+                    elif nb_version in (4, 5):
                         cells.append(new_code_cell(
                             source=block,
                             execution_count=prompt_number,
@@ -650,7 +650,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             block = block.rstrip()
             if nb_version == 3:
                 print("WARNING: Output not implemented for nbformat v3.")
-            elif nb_version == 4:
+            elif nb_version in (4, 5):
                 outputs = [
                     {
                         "data": {
@@ -681,7 +681,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             if nb_version == 3:
                 nb.cells.append(new_code_cell(
                     input=block, prompt_number=prompt_number, collapsed=True))
-            elif nb_version == 4:
+            elif nb_version in (4, 5):
                 cells.append(new_code_cell(
                     source=block,
                     execution_count=prompt_number,
@@ -720,7 +720,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
 
         # Convert nb to json format
         filestr = nbjson.writes(nb)
-    elif nb_version == 4:
+    elif nb_version in (4, 5):
         nb = new_notebook(cells=cells)
         try:
             from nbformat import writes


### PR DESCRIPTION
**Update lib/ipynb.py with additional checks to nb_version 5**
Previous commit added a check to lib/ipynb.py for to include nb_version 5; there were 6 other locations in that file where the check should have been added.

**Add jupyter to required dependencies** 
Tried compiling doc/src/slides/minidemo.do.txt but got error when running the associated bash.sh - could not convert to .ipynb. After pip installing jupyter, the minidemo could be converted to .ipynb.