### PR TITLE
Fix Spinger_T2 book test

### DIFF
--- a/test/Springer_T2/Springer_T2_book.do.txt
+++ b/test/Springer_T2/Springer_T2_book.do.txt
@@ -120,6 +120,7 @@ All program examples in this ${CHAPTER} can be found as files in the
 folder "`src/plot`": "${src_path}/plot".
 
 ======= Arrays in Python programs =======
+label{sec:plot:arraycomp}
 
 This section introduces array programming in Python, but first we
 create some lists and show how arrays differ from lists.

--- a/test/Springer_T2/make.sh
+++ b/test/Springer_T2/make.sh
@@ -13,21 +13,13 @@ function system {
 
 rm -f tmp_*
 
-system doconce format pdflatex $name CHAPTER=chapter BOOK=book APPENDIX=appendix -DPRIMER_BOOK ALG=code --encoding=utf-8 --device=paper --exercise_numbering=chapter --latex_admon_color=1,1,1 --latex_admon=mdfbox  --latex_style=Springer_$style --latex_title_layout=titlepage --latex_list_of_exercises=loe --latex_table_format=center --latex_admon_title_no_period --exercises_in_zip --exercises_in_zip_filename=chapter --allow_refs_to_external_docs
+system doconce format pdflatex $name CHAPTER=chapter BOOK=book APPENDIX=appendix -DPRIMER_BOOK ALG=code --latex_code_style=lst --encoding=utf-8 --device=paper --exercise_numbering=chapter --latex_admon_color=1,1,1 --latex_admon=mdfbox  --latex_style=Springer_$style --latex_title_layout=titlepage --latex_list_of_exercises=loe --latex_table_format=center --latex_admon_title_no_period --exercises_in_zip --exercises_in_zip_filename=chapter --allow_refs_to_external_docs
 
-
-PYTHON_VERSION=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
-parsedVersion=$(echo "${PYTHON_VERSION//./}")
-if [ "$parsedVersion" -lt "300" ]
-then
-	system ptex2tex $name
-	rm -rf $name.aux $name.ind $name.idx $name.bbl $name.toc $name.loe
-
-	system pdflatex $name
-	system bibtex $name
-	system makeindex $name
-	system pdflatex $name
-	system pdflatex $name
-	rm -rf standalone_exercises
-	unzip Springer_T2_book_exercises.zip
-fi
+rm -rf $name.aux $name.ind $name.idx $name.bbl $name.toc $name.loe
+system pdflatex $name
+system bibtex $name
+system makeindex $name
+system pdflatex $name
+system pdflatex $name
+rm -rf standalone_exercises
+unzip Springer_T2_book_exercises.zip


### PR DESCRIPTION
I ran into issues running this test because the make.sh generated a p.tex file and the called ptex2tex. It is discouraged to use this package, and it is actually currently not possible to install this package with Python 3. 
 
I have implemented the recommended fix: added  a `--latex_code_style=` option to the doconce call. This means a .tex file is produced, doing away with the need to call ptex2tex.

I also added  missing label{} that was causing the pdflatex compile to run into problems.