### PR TITLE
Issue #60: Fix format latex --execute and numbered figure labels

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -1011,7 +1011,7 @@ def define(FILENAME_EXTENSION,
 
         'separator': '\n',
         }
-    CROSS_REFS['ipynb'] = pandoc_ref_and_label
+    CROSS_REFS['ipynb'] = ipynb_ref_and_label
 
     TABLE['ipynb'] = ipynb_table
     cite = option('ipynb_cite=', 'plain')

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -9,6 +9,7 @@ standard_library.install_aliases()
 from builtins import zip
 from builtins import str
 from builtins import range
+from builtins import bytes
 from past.utils import old_div
 import os, subprocess, re, sys, glob, shutil, subprocess
 from .common import plain_exercise, table_analysis, \
@@ -18,7 +19,9 @@ from .common import plain_exercise, table_analysis, \
 from .misc import option, _abort, replace_code_command
 from .doconce import errwarn, debugpr
 from doconce import globals
-
+import base64
+import uuid
+import os
 additional_packages = ''  # comma-sep. list of packages for \usepackage{}
 
 include_numbering_of_exercises = True


### PR DESCRIPTION
Add a couple of imports, and use numbered labels for figures when formatting to latex with `--execute`