### PR TITLE
Fix manual.do.txt to allow pdflatex compile

### DIFF
--- a/doc/src/manual/manual.do.txt
+++ b/doc/src/manual/manual.do.txt
@@ -4812,7 +4812,7 @@ doconce replace 'bibliographystyle{plain}' 'bibliographystyle{abbrev}' mydoc.p.t
 ======= Preprocessing and Postprocessing =======
 
 idx{split command}
-idx{`!split`}
+# idx{`!split`}
 idx{preprocessing}
 idx{postprocessing}
 


### PR DESCRIPTION
manual.do.txt contained an index entry that was causing problems: idx{\`!split\`}. It was assumed the back-ticks would allow this entry to work. However, because DocOnce uses the `!` symbol to separate index levels, it appears this was causing a problem. The index entry was removed.