### PR TITLE
Fix formatting of multi-author notebook

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -45,10 +45,8 @@ def ipynb_author(authors_and_institutions, auth2index,
             s += ' at ' + ' & '.join(i)
         s += ' -->\n'
         # Add extra line between heading and first author
-        if first_pass:
-            s+= '<!-- Author: -->  \n_%s_' % (author)
-        else:
-            s+= '<!-- Author: --> _%s_' % (author)
+        # and between all next authors
+        s+= '<!-- Author: -->  \n_%s_' % (author)
         if e is not None:
             s += ' (email: `%s`)' % e
         if i is not None:


### PR DESCRIPTION
When multiple authors are listed, rendering these in the notebook causes misformatting with ** around their names instead of bold names.

Current situation:

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1122351/107244822-bd2fd300-6a2e-11eb-94ec-96acaccef403.png">

With this fix:

<img width="874" alt="image" src="https://user-images.githubusercontent.com/1122351/107245084-0aac4000-6a2f-11eb-861f-e3febbfa8747.png">

This is an OK solution. Ideally, there would be no empty line between each author, but I have not figured out how to do that.