### PR TITLE
Complete pull request #93

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -49,23 +49,23 @@ def ipynb_author(authors_and_institutions, auth2index,
     # -----------------------------------------------------
     # New code: typeset as lines, but insert a comment so we
     # can convert back <!-- dom:AUTHOR: ... ->
+    # Feb 2021: Not sure what was the use for these comments.
+    # They insert an unwanted line between each author
     s = '\n'
-    first_pass = True
     for author, i, e in authors_and_institutions:
-        s+= '<!-- dom:AUTHOR: ' + author
+        '''
+        s += '<!-- dom:AUTHOR: ' + author
         if e is not None:
             s += ' Email:' + e
         if i is not None:
             s += ' at ' + ' & '.join(i)
-        s += ' -->\n'
-        # Add extra line between heading and first author
-        # and between all next authors
-        s+= '<!-- Author: -->  \n_%s_' % (author)
+        s += ' -->\n'  
+        '''
+        s += '<!-- Author: -->  \n_%s_' % (author)
         if e is not None:
             s += ' (email: `%s`)' % e
         if i is not None:
             s += ', ' + ' and '.join(i)
-        first_pass = False
         s += '  \n'
     return s
 


### PR DESCRIPTION
This builds on top of [Pull Request 93](https://github.com/doconce/doconce/pull/93). This removes some html comments that cause the ipynb to show a line between authors. There are these comments in the code: 

> \# New code: typeset as lines, but insert a comment so we
> \# can convert back <!-- dom:AUTHOR: ... ->

but I could not find trace in the repository of what they could be used for, so i just removed them