### PR TITLE
jupyterbook fix path of images and figures

### DIFF
--- a/lib/doconce/DocWriter.py
+++ b/lib/doconce/DocWriter.py
@@ -605,7 +605,7 @@ class HTML(_BaseWriter):
             height = ' width=%s ' % width
         else:
             height = ''
-        s = '\n<hr><img src="%s"%s%s>\n<p><em>%s</em>\n<hr><p>\n' % \
+        s = '\n<hr><img src="%s"%s%s>\n<p><em>%s</em></p>\n<hr><p>\n' % \
             (filename, width, height, caption)
         self.file.write(s)
 

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -39,6 +39,14 @@ color_table = [
     ('blue', '#0000FF', 'rgb(0,0,255)'),
     ('navy', '#000080', 'rgb(0,0,128)'),]
 
+# html code and corresponding regex (here for reusability)
+movie2html = {
+    '.mp4': "\n    <source src='%(stem)s.mp4'  type='video/mp4;  codecs=\"avc1.42E01E, mp4a.40.2\"'>",
+    '.webm': "\n    <source src='%(stem)s.webm' type='video/webm; codecs=\"vp8, vorbis\"'>",
+    '.ogg': "\n    <source src='%(stem)s.ogg'  type='video/ogg;  codecs=\"theora, vorbis\"'>",
+    'movie_regex':
+        r'<(\w+) src=\'(.+)\'\s+type=\'video/(?:mp4|webm|ogg);\s+codecs=[\\]{0,1}\".+[\\]{0,1}\"\'>',
+}
 
 
 def add_to_file_collection(filename, doconce_docname=None, mode='a'):
@@ -2020,14 +2028,6 @@ def html_movie(m):
                     "<div>\n"
                     "<video %(autoplay)s loop controls width='%(width)s' height='%(height)s' preload='none'>") \
                    % vars()
-            ext2source_command = {
-                '.mp4': """
-    <source src='%(stem)s.mp4'  type='video/mp4;  codecs="avc1.42E01E, mp4a.40.2"'>""" % vars(),
-                '.webm': """
-    <source src='%(stem)s.webm' type='video/webm; codecs="vp8, vorbis"'>""" % vars(),
-                '.ogg': """
-    <source src='%(stem)s.ogg'  type='video/ogg;  codecs="theora, vorbis"'>""" % vars(),
-                }
             movie_exists = False
             mp4_exists = False
             if sources3:
@@ -2037,19 +2037,19 @@ def html_movie(m):
                 # can play on iOS.
                 msg = 'movie: trying to find'
                 if is_file_or_url(stem + '.mp4', msg) in ('file', 'url'):
-                    text += ext2source_command['.mp4']
+                    text += movie2html['.mp4'] % vars()
                     movie_exists = True
                     mp4_exists = True
                 if is_file_or_url(stem + '.webm', msg) in ('file', 'url'):
-                    text += ext2source_command['.webm']
+                    text += movie2html['.webm'] % vars()
                     movie_exists = True
                 if is_file_or_url(stem + '.ogg', msg) in ('file', 'url'):
-                    text += ext2source_command['.ogg']
+                    text += movie2html['.ogg'] % vars()
                     movie_exists = True
             else:
                 # Load just the specified file
                 if is_file_or_url(stem + ext, msg) in ('file', 'url'):
-                    text += ext2source_command[ext]
+                    text += movie2html[ext] % vars()
                     movie_exists = True
             if not movie_exists:
                 errwarn('*** warning: movie "%s" was not found' % filename)
@@ -2062,8 +2062,8 @@ def html_movie(m):
             text += ("\n"
                      "</video>\n"
                      "</div>\n"
-                     "<p><em>%(caption)s</em></p>\n"
-                     ) % vars()
+                     "<p><em>%s</em></p>\n"
+                     ) % caption
             #if not mp4_exists:
             if True:
                 # Seems that there is a problem with .mp4 movies as well...

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -9590,3 +9590,63 @@ def extract_exercises():
     f.write(filestr)
     f.close()
     print('exercises extracted to', filename)
+
+
+def find_file_with_extensions(filename_in, allowed_extensions=['']):
+    """Check the existence of a filename having given extensions.
+    Return relative directory, basename, extension, and complete filename,
+
+    Given an input filename (e.g. './book' or 'mybook/book.do.txt') and a
+    list of allowed extensions (e.g. ['.do.txt']), return the file's
+    relative directory ('' or 'mybook', but never '.' or './), basename
+    ('book'), extension ('do.txt'), and complete filename ('book.do.txt')
+    dirname, basename, and filename. './' is stripped of all output.
+    Use `allowed_extensions=''` for checking exact matches, but the
+    extension is ''. Return a tuple of None if the file was not found.
+    :param str filename_in: Filename or its basename.
+    :param list(str) allowed_extensions: list of legal extensions
+    :return: tuple of dirname, basename, extension, and filename
+    :rtype: (str, str, str, str)
+    """
+    # Get the directory name. It can be relative
+    dirname = os.path.dirname(filename_in)
+    if dirname == '.':
+        dirname = ''
+    if dirname.startswith('./'):
+        print('fix this!')
+        _abort()
+
+    ext, basename, filename_out = None, None, None
+    dir_basename = filename_in
+    # Try to split every allowed suffix from input filename.
+    # If it works, check if the file exists
+    for ext_i in allowed_extensions:
+        if ext_i != '':
+            tmp = filename_in.split(ext_i)
+            if len(tmp) == 2 and tmp[-1] == '':
+                dir_basename = tmp[0]
+        #else:
+            #dir_basename = filename_in
+            #if ext_i.endswith(''):
+            #    ext_i = ext_i[:-1]
+
+        # Check that the filename exists
+        if os.path.isfile(dir_basename + ext_i):
+            # Extension found
+            ext = ext_i
+            basename = os.path.basename(dir_basename)
+            # Compose the filename (basename + suffix, but no path)
+            filename_out = basename + ext
+            break
+    if ext == None:
+        print('*** error: could not find any file "%s*"' % filename_in)
+        print('    with extensions %s' % ' , '.join(allowed_extensions))
+        dirname, basename = None, None
+        #_abort()
+    # Remove initial '.' or  './'
+    if basename and basename.startswith('./'):
+        basename = basename[2:]
+    if filename_out and filename_out.startswith('./'):
+        filename_out = filename_out[2:
+                       ]
+    return dirname, basename, ext, filename_out

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
         'mako',
         'future',
         'pygments-doconce',
-        'publish-doconce'
+        'publish-doconce',
+        'requests'
         ],
     #data_files=[(os.path.join("share", "man", "man1"),[man_filename,]),],
     package_data = {'': ['sphinx_themes.zip', 'html_images.zip', 'reveal.js.zip', 'deck.js.zip', 'csss.zip', 'latex_styles.zip']},


### PR DESCRIPTION
This should fix issue #100 , except for the fact that movies are not supported in Jupyter Book (see [github.com/executablebooks/jupyter-book/issues/1249](https://github.com/executablebooks/jupyter-book/issues/1249#issuecomment-786763353) ). 

For this issue I replaced the utility `parse_doconce_filename` in `lib/doconce/doconce.py` with `find_file_with_extensions` in `misc.py`, which is more general. I also tried to keep some of the regex expressions used close to their corresponding html code in `lib/doconce/ipynb.py` and `lib/doconce/html.py`. This should enhance reusability and perhaps help to avoid errors when one wants to modify the html code.