### PR TITLE
issue #100: fix after cd in input file

### DIFF
--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -9655,8 +9655,8 @@ def find_file_with_extensions(filename_in, allowed_extensions=['']):
     if dirname == '.':
         dirname = ''
     if dirname.startswith('./'):
-        print('fix this!')
-        _abort()
+        dirname = dirname[2:]
+        #_abort()
 
     ext, basename, filename_out = None, None, None
     dir_basename = filename_in


### PR DESCRIPTION
With commit `ee33a980`, `jupyterbook.py` does a cd in the DocOnce file's directory. In some cases this messed up the correction of the paths of media (issue #100 ). This should be ok now. 

I also corrected a loop in `split_ipynb`, which was not splitting the ipynb correctly.