### PR TITLE
issue 98: fix regex to include backslashes

### DIFF
--- a/lib/doconce/jupyterbook.py
+++ b/lib/doconce/jupyterbook.py
@@ -579,7 +579,10 @@ def get_link_destinations(chunk):
     destinations, destination_tags = [], []
     # html links. label{} has already been converted
     pattern_tag = r'[\w _\-:]'
-    pattern = r'<' + pattern_tag + '+ (id|name)=["\'](' + pattern_tag + '+)["\'][^>]*>'
+    pattern_backslash = '[\\\]'
+    pattern = r'<' + pattern_tag + \
+              '+ (id|name)=' + pattern_backslash + '["\']' + \
+              '(' + pattern_tag + '+)' + pattern_backslash + '["\'][^>]*>'
     for m in re.finditer(pattern, chunk):
         match = m.group()
         tag = m.group(2)


### PR DESCRIPTION
Fix regex used in `lib/doconce/jupyterbook.py` > `get_link_destinations` to resolve link destinations across different pages. Somehow the texts of ipynb files were encoded with more backslashes than when I developed this functionality, so I had to fix the regex. 
I am preparing tests for this low-level functions. Hopefully they will help catching these issues in the future
