### PR TITLE
Add missing formats

### DIFF
--- a/doc/src/manual/manual.do.txt
+++ b/doc/src/manual/manual.do.txt
@@ -3538,7 +3538,7 @@ ZeroDivisionError: division by zero
 |ec
 !ec
 
-All formats other than ipynb, matlabnb formats ignore the `-t` postfix.
+All formats other than ipynb, matlabnb, html and pdflatex formats ignore the `-t` postfix.
 
 === Hiding code blocks ===
 


### PR DESCRIPTION
Are there more? Or is it all formats that do not support `--execute` also ignore `-t`?