### PR TITLE
issue #194: solution and stand-alone files with --exercises_in_zip

### DIFF
--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -835,7 +835,7 @@ def add_labels_to_all_numbered_equations(tex_blocks):
 
 
 def insert_code_blocks(filestr, code_blocks, format, complete_doc=True, remove_hid=True):
-    """ Insert code blocks in file
+    """Insert code blocks in file
 
     Insert in the DocOnce file verbatim code blocks previously extracted by
     the `remove_code_and_tex` function and stored separately in lists.
@@ -959,17 +959,21 @@ def remove_hidden_code_blocks(filestr, format):
     return filestr
 
 
-def doconce_exercise_output(
-    exer,
-    solution_header = '__Solution.__',
-    answer_header = '__Answer.__',
-    hint_header = '__Hint.__',
-    include_numbering=True,
-    include_type=True,
-    ):
-    """
-    Write exercise in DocOnce format. This output can be
-    reused in most formats.
+def doconce_exercise_output(exer, solution_header = '__Solution.__', answer_header = '__Answer.__',
+                            hint_header = '__Hint.__', include_numbering=True, include_type=True):
+    """Write exercise in DocOnce format.
+
+    Write exercise in DocOnce format. This output can be reused in most formats.
+    Code and latex (math) blocks are replaced with the _CODE_BLOCK and _MATH_BLOCK identifiers
+    in all output. Use the insert_code_blocks function to insert code blocks.
+    :param dict exer: data structure for exercises
+    :param str solution_header: default '__Solution.__'
+    :param str answer_header: default '__Answer.__'
+    :param str hint_header: default '__Hint.__'
+    :param bool include_numbering: default True
+    :param bool include_type: default True
+    :return: exercise and answers/solutions formatted in doconce formats
+    :rtype: Tuple[str, str]
     """
     # Note: answers, solutions, and hints must be written out and not
     # removed here, because if they contain math or code blocks,

--- a/lib/doconce/globals.py
+++ b/lib/doconce/globals.py
@@ -468,11 +468,11 @@ def lookup_locale_dict(key, fallback_to_english=True):
 doconce_commands = "help, format, find, subst, replace, remove, spellcheck, apply_inline_edits, capitalize, " \
                    "change_encoding, clean, combine_images, csv2table, diff, expand_commands, expand_mako, extract_exercises, " \
            "find_nonascii_chars, fix_bibtex4publish, gitdiff, grab, grep, guess_encoding, gwiki_figsubst, html2doconce, " \
-           "html_colorbullets, jupyterbook, include_map, insertdocstr, ipynb2doconce, latex2doconce, latex_dislikes, " \
-           "latex_exercise_toc, latex_footer, latex_header, latex_problems, latin2html, lightclean, linkchecker, " \
-           "list_fig_src_files, list_labels, makefile, md2html, md2latex, old2new_format, ptex2tex, pygmentize, " \
-           "ref_external, remove_exercise_answers, remove_inline_comments, replace_from_file, slides_beamer, " \
-           "slides_html, slides_markdown, sphinx_dir, sphinxfix_localURLs, split_html, split_rst, teamod".split(", ")
+       "html_colorbullets, jupyterbook, include_map, insertdocstr, ipynb2doconce, latex2doconce, latex_dislikes, " \
+       "latex_exercise_toc, latex_footer, latex_header, latex_problems, latin2html, lightclean, linkchecker, " \
+       "list_fig_src_files, list_labels, makefile, md2html, md2latex, old2new_format, ptex2tex, pygmentize, " \
+       "ref_external, remove_exercise_answers, remove_inline_comments, replace_from_file, slides_beamer, " \
+       "slides_html, slides_markdown, sphinx_dir, sphinxfix_localURLs, split_html, split_rst, teamod".split(", ")
 
 _registered_commands = [
     ('format', 'Transform doconce file to another format'),
@@ -540,11 +540,11 @@ doconce_commands = list(map(lambda t: t[0], _registered_commands))
 old = "help, format, find, subst, replace, remove, spellcheck, apply_inline_edits, capitalize, change_encoding, " \
            "clean, combine_images, csv2table, diff, expand_commands, expand_mako, extract_exercises, " \
            "find_nonascii_chars, fix_bibtex4publish, gitdiff, grab, grep, guess_encoding, gwiki_figsubst, html2doconce, " \
-           "html_colorbullets, jupyterbook, include_map, insertdocstr, ipynb2doconce, latex2doconce, latex_dislikes, " \
-           "latex_exercise_toc, latex_footer, latex_header, latex_problems, latin2html, lightclean, linkchecker, " \
-           "list_fig_src_files, list_labels, makefile, md2html, md2latex, old2new_format, ptex2tex, pygmentize, " \
-           "ref_external, remove_exercise_answers, remove_inline_comments, replace_from_file, slides_beamer, " \
-           "slides_html, slides_markdown, sphinx_dir, sphinxfix_localURLs, split_html, split_rst, teamod".split(", ")
+      "html_colorbullets, jupyterbook, include_map, insertdocstr, ipynb2doconce, latex2doconce, latex_dislikes, " \
+      "latex_exercise_toc, latex_footer, latex_header, latex_problems, latin2html, lightclean, linkchecker, " \
+      "list_fig_src_files, list_labels, makefile, md2html, md2latex, old2new_format, ptex2tex, pygmentize, " \
+      "ref_external, remove_exercise_answers, remove_inline_comments, replace_from_file, slides_beamer, " \
+      "slides_html, slides_markdown, sphinx_dir, sphinxfix_localURLs, split_html, split_rst, teamod".split(", ")
 
 _registered_command_line_options = [
     ('--help', 'Print all command-line options for doconce'),
@@ -578,7 +578,8 @@ _registered_command_line_options = [
     ('--IBPLOT', 'automagic translation of IBPLOT commands.'),
     ('--exercise_numbering=', 'absolute: exercises numbered as 1, 2, ... (default); chapter: exercises numbered '
                     'as 1.1, 1.2, ... , 3.1, 3.2, ..., B.1, B.2, etc. with a chapter or appendix prefix.'),
-    ('--exercises_in_zip', 'Place each exercises as an individual DocOnce file in a zip archive.'),
+    ('--exercises_in_zip', 'Place the answers+solutions and each exercise as an individual DocOnce file '
+                           'in a zip archive.'),
     ('--exercises_in_zip_filename=', 'Filenames of individual exercises in zip archive. logical: use the (first) '
                     'logical filename specified by file=... ; number:  use either absolute exercise number or '
                     'chapter.localnumber.'),

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -6245,8 +6245,7 @@ def makefile():
         formats = ['pdflatex', 'html', 'sphinx', 'deck', 'reveal', 'beamer']
 
     make = open('make.py', 'w')
-    make.write('''\
-#!/usr/bin/env python
+    make.write('''#!/usr/bin/env python
 """
 Automatically generated file for compiling doconce documents.
 """


### PR DESCRIPTION
The `--exercises_in_zip` option creates a `standalone_exercises.zip` file with solutions of exercises and stand-alone exercises, and a `make.py` file to compile to `latex`, `html`, `ipynb`. 

I removed the generation of the `<file>_exersol.do.txt` when formatting to `ipynb`.  
I did not remove the genaration of `<file>.exerinfo` file because it is used by some other functionalities.  