### PR TITLE
issue #191: get TITLE and copyright right in ipynb

### DIFF
--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -232,14 +232,17 @@ def get_copyfile_info(filestr=None, copyright_filename=None, format=None):
 
     # We have copyright file and info
     cr_text = ''
+    if 'copyright' in cr_info:
+        cr_text += 'Copyright: ' + cr_info['copyright']
     if 'year' in cr_info and 'holder' in cr_info:
-        cr_text += cr_info['year'] + ', ' + ', '.join(cr_info['holder'])
+        cr_text += str(cr_info['year'])
+        cr_text += ', ' + ', '.join(cr_info['holder']) + '. '
     if cr_info.get('license', None) is not None:
-        cr_text += '. ' + cr_info['license']
+        cr_text += cr_info['license']
     if cr_info.get('cite doconce', False):
         url = 'https://github.com/doconce/doconce'
         if cr_text:
-            cr_text += '. '
+            cr_text += '\n\n'
         cr_text += 'Made with '
         if format in ('latex', 'pdflatex'):
             cr_text += r'\href{%s}{DocOnce}' % url

--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -4195,7 +4195,7 @@ def inline_tag_subst(filestr, format):
                 if cr_text == 'Made with DocOnce':
                     date += '\n\nMade with DocOnce\n\n'
                 else:
-                    date += '\n\nCopyright ' + cr_text + '\n\n'
+                    date += '\n\n' + cr_text + '\n\n'
         try:
             filestr = filestr.replace(origstr, 'DATE: ' + date)
         except UnicodeDecodeError:

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -964,7 +964,7 @@ def define(FILENAME_EXTENSION,
         'linkURL3v': r'[`\g<link>`](\g<url>)',
         'plainURL':  r'<\g<url>>',
         'colortext': r'<font color="\g<color>">\g<text></font>',
-        'title':     r'<!-- dom:TITLE: \g<subst> -->\n# \g<subst>',
+        'title':     r'# \g<subst>',
         'author':    ipynb_author,
         'date':      '\nDate: _\g<subst>_\n',
         'chapter':       lambda m: '# '   + m.group('subst'),  # seldom used in notebooks


### PR DESCRIPTION
The `TITLE: ` heading was not implemented for the `ipynb` format. I had to modify how the copyright is rendered, and describe the hidden feature `<file>.copyright` in the docs. I also added a mini guide about using git in the development guide `doc/devel`