### PR TITLE
issue #192: encode executed code output in html format

### DIFF
--- a/lib/doconce/jupyter_execution.py
+++ b/lib/doconce/jupyter_execution.py
@@ -17,7 +17,7 @@ from .misc import errwarn, _abort, option
 from .globals import envir2syntax, syntax_executable
 from .common import safe_join, get_code_block_args
 from pygments.lexers import get_lexer_by_name
-
+from html import escape
 
 class JupyterKernelClient:
     """Create and start a Jupyter kernel in a programming language.
@@ -407,7 +407,10 @@ def execute_code_block(current_code, current_code_envir, kernel_client, format, 
         begin, end = formatted_code_envir("pyout", code_style, format)
         for output in outputs:
             if "text" in output:
-                text_output = ansi_escape.sub("", output["text"])
+                text_output = output["text"]
+                if format in ['html']:
+                    text_output = escape(text_output)
+                text_output = ansi_escape.sub("", text_output)
                 text_out += "\n{}\n{}{}".format(begin, text_output, end)
             if "data" in output:
                 data = output["data"]


### PR DESCRIPTION
When using `doconce format html <file> --execute`, some output code can contain characters such as `<>&` that should be necoded otherwise they get interpreted as HTML code. I encoded all code output using the escape function from `from html import escape`. 
Example: 
```
!bc pycod
x = 3
print(type(x))
!ec
```

used to yield `<class 'int'>`, which in a browser does not show up at all. Now the encoded output is `&lt;class&gt;`