### PR TITLE
issue #187: show figure numbering in html, rm colon if no caption

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -164,6 +164,8 @@ def ipynb_figure(m):
                                            opts=opts,
                                            caption=caption,
                                            figure_number=figure_number)
+        if not caption:
+            text = text.replace('Figure ' + str(figure_number) + ': ', 'Figure ' + str(figure_number))
     elif display_method == 'Image':
         # Image object
         # NOTE: This code will normally not work because it inserts a verbatim
@@ -881,6 +883,7 @@ def ipynb_index_bib_latex_plain(filestr, index, citations, pubfile, pubdata):
 
 
 def ipynb_ref_and_label(section_label2title, format, filestr):
+    # NB: figure numbering already done in `handle_figures` > `ipynb_figure`
     filestr = fix_ref_section_chapter(filestr, format)
 
     # Replace all references to sections. Pandoc needs a coding of

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -162,7 +162,6 @@ def option(name, default=None, option_list = _legal_command_line_options):
     the option ``--name`` is found or not.
     Abort if the option ``--name`` is not valid, ie not present in ``option_list``.
 
-
     :param str name: filename to be read
     :param any default: optional encoding string. Usually the encoding variable in globals.py
     :param list[str] option_list: optional list of command options. Default is _legal_command_line_options from globals._registered_command_line_options
@@ -7362,7 +7361,7 @@ def extract_exercises():
 
 def find_file_with_extensions(filename_in, allowed_extensions=['']):
     """Check the existence of a filename having given extensions.
-    Return relative directory, basename, extension, and complete filename,
+    Return relative directory, basename, extension, and complete filename.
 
     Given an input filename (e.g. './book' or 'mybook/book.do.txt') and a
     list of allowed extensions (e.g. ['.do.txt']), return the file's
@@ -7373,6 +7372,7 @@ def find_file_with_extensions(filename_in, allowed_extensions=['']):
     Relative directories such as './', '../' are stripped of all output.
     Use `allowed_extensions=''` for checking exact matches, but this causes
     the extension to be ''. Return a tuple of None if the file was not found.
+
     :param str filename_in: Filename or its basename.
     :param list(str) allowed_extensions: list of legal extensions
     :return: tuple of dirname, basename, ext, and filename


### PR DESCRIPTION
Figure captions are enabled even when there is no caption. The figures will show e.g. `Figure 1`. For the `ipynb` format I removed the colon when there is no caption, for example `Figure 1: ` to `Figure 1`.
I simplified code in `doconce.py` > `handle_figures`.