### PR TITLE
Make code compatible with jupyter-client 7.0, add regex in dependencies

### DIFF
--- a/lib/doconce/jupyter_execution.py
+++ b/lib/doconce/jupyter_execution.py
@@ -105,7 +105,7 @@ class JupyterKernelClient:
         # wait for finish, with timeout
         while True:
             try:
-                msg = self.client.shell_channel.get_msg(timeout=timeout)
+                msg = self.client.get_shell_msg(timeout=timeout)
             except Empty:
                 print("Timeout waiting for execute reply", timeout)
                 print("Tried to run the following source:\n{}".format(source))
@@ -131,7 +131,7 @@ class JupyterKernelClient:
                 # in certain CI systems, waiting < 1 second might miss messages.
                 # So long as the kernel sends a status:idle message when it
                 # finishes, we won't actually have to wait this long, anyway.
-                msg = self.client.iopub_channel.get_msg(timeout=5)
+                msg = self.client.get_iopub_msg()
             except Empty:
                 if misc.option('verbose-execute'):
                     print("Timeout waiting for IOPub output")

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools.setup(
         'publish-doconce',
         'requests',
         'nbformat',
-        'jupyter_client'
+        'jupyter_client',
+        'regex'
         ],
     #data_files=[(os.path.join("share", "man", "man1"),[man_filename,]),],
     package_data = {'': ['sphinx_themes.zip', 'html_images.zip', 'reveal.js.zip', 'deck.js-latest.zip', 'csss.zip', 'latex_styles.zip']},


### PR DESCRIPTION
jupyter-client 7.0 changed the API. Two methods used in DocOnce might have been good some time ago but I found others that should be compatible in versions 6.0 and 7.0 alike

I am getting some errors when formatting to ipynb using `--execute`, and hopefully adding `regex` to the dependencies of the DocOnce in PyPi will at least help