### PR TITLE
fix tests and execute_code_block in ipynb.py

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -867,7 +867,7 @@ def execute_code_block(block, current_code_envir, kernel_client, execution_count
         if option("execute"):
             outputs, execution_count_out = kernel_client.run_cell(blockline)
             # Extract any error in code
-            error = check_errors_in_code_output(outputs)
+            error = check_errors_in_code_output(outputs, execution_count)
             for output in outputs:
                 if output['output_type'] == 'error':
                     traceback = ''

--- a/lib/doconce/jupyter_execution.py
+++ b/lib/doconce/jupyter_execution.py
@@ -31,6 +31,7 @@ class JupyterKernelClient:
         - Install the IJulia Jupyter kernel with `using Pkg; Pkg.add("IJulia");Pkg.build("IJulia")` in julia
         - Uninstall IJulia: `Pkg.rm("IJulia")` in julia, then `jupyter kernelspec uninstall mykernel`
         - Install the bash kernel: https://github.com/takluyver/bash_kernel
+        also make sure the bash_kernel package is installed: `pip install bash_kernel`
         - Install the IR kernel for R: https://irkernel.github.io/installation/
         after upgrading to R 3.4+: https://github.com/duckmayr/install-update-r-on-linux
         - List the currently installed kernels: jupyter kernelspec list


### PR DESCRIPTION
The tests were failing, in particular `test_doconce_format_execute` in `test/pytests.py` when testing formatting code to bash and ipynb. `lib/doconce/ipynb.py` had a bug (somehow there was a missing argument when calling `check_errors_in_code_output`). execution of bash code in a bash jupyter kernel got fixed probably by upgrading the kernel or the `bash_kernel` python package