### PR TITLE
issue #213: reproducible IDs in ipynb format

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from builtins import str
 from builtins import range
+import hashlib
 import sys, shutil, os
 import regex as re
 import shlex
@@ -695,7 +696,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             cells.append(new_markdown_cell(source=block, metadata=dict(editable=editable_md)))
             #mdstr.append(('markdown', block))
         elif block_tp == 'cell':
-            # TODO: now I need to handle -hid also in 'markdown' type. actually the logic on postfixes should be separated from LANG
+            # TODO: now I need to handle -hid also in 'markdown' formats. The logic on postfixes should actually be
+            # separated from LANG
             LANG, codetype, postfix, postfix_err = get_code_block_args('!bc ' + notebook_block_envir[j])
             j += 1
             execute, show = get_execute_show((LANG, codetype, postfix))
@@ -749,6 +751,13 @@ def ipynb_code(filestr, code_blocks, code_block_types,
                     for cell in cells_output:
                         if cell:
                             cells.append(cell)
+
+    # Replace the random id with a reproducible hash of the content (issue #213)
+    # nbformat 5.1.3 creates random cell ID with `uuid.uuid4().hex[:8]`
+    for i in range(len(cells)):
+        if 'id' in cell.keys():
+            cell_content = str(i) + cells[i]['source']
+            cells[i]['id'] = hashlib.sha224(cell_content.encode()).hexdigest()[:8]
 
     # Create the notebook in string format
     nb = new_notebook(cells=cells)


### PR DESCRIPTION
Replace all random id in the cells of ipynb files with a hash of the cell content and cell number. In this way the cell ids on different runs of e.g. `doconce format ipynb <file>` will be the same