### PR TITLE
Fix ipython dependency for python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ ipython-genutils==0.2.0
 ipywidgets==7.5.1
 jedi==0.17.2
 Jinja2==2.11.2
-jsonschema==4.2.1
+jsonschema>=4.0.0
 jupyter==1.0.0
 jupyter-client==6.1.7
 jupyter-console==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.3.0
 ipykernel==5.4.2
-ipython==7.29.0
+ipython>=7.0.0
 ipython-genutils==0.2.0
 ipywidgets==7.5.1
 jedi==0.17.2


### PR DESCRIPTION
GitHub actions fail for python 3.6 with 
"ERROR: No matching distribution found for ipython==7.29.0"
I change that dependency in `requirements.txt` as `ipython>=7.0.0`