### PR TITLE
Add timeout in jupyter_client.client.get_iopub_msg()

### DIFF
--- a/lib/doconce/jupyter_execution.py
+++ b/lib/doconce/jupyter_execution.py
@@ -132,7 +132,7 @@ class JupyterKernelClient:
                 # in certain CI systems, waiting < 1 second might miss messages.
                 # So long as the kernel sends a status:idle message when it
                 # finishes, we won't actually have to wait this long, anyway.
-                msg = self.client.get_iopub_msg()
+                msg = self.client.get_iopub_msg(timeout=5)
             except Empty:
                 if misc.option('verbose-execute'):
                     print("Timeout waiting for IOPub output")


### PR DESCRIPTION
pytests are hanging GitHub actions, most of all for python 3.6 and 3.9. When I try to reproduce the issue on my local machine, the issues seem to happen sporadically. At some point I noticed that code was hanging on the `get_iopub_msg()` method from `jupyter_client.client`, and adding a timeout of 5 seconds seemed to help