### PR TITLE
Add -noex option for skipping execution of codecell in ipynb

### DIFF
--- a/lib/doconce/globals.py
+++ b/lib/doconce/globals.py
@@ -50,7 +50,7 @@ LANG = list(envir2syntax.keys())
 # Additional envirs in the .ptex2tex.cfg file as of June 2012.
 # Recall that the longest names must come first to be substituted first e.g. bccod before bcc
 # Postfixes allowed on code blocks e.g. `pycod-e` and regex to catch them
-postfix_code_block = ['-hid', '-h', '-e', '-t', '-out', 'hid', 'out']
+postfix_code_block = ['-hid', '-h', '-e', '-t', '-out', 'hid', 'out', '-noex']
 postfix_err = '-err'
 # Code block regex pattern
 # '[\w]*?' (any word, non greedy) takes care of additional envirs in the .ptex2tex.cfg file

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -890,7 +890,7 @@ def execute_code_block(block, current_code_envir, kernel_client, execution_count
             execution_count=execution_count,
             metadata=dict(editable=editable, collapsed=collapsed)
         )
-        if option("execute"):
+        if option("execute") and postfix != "-noex":
             outputs, execution_count_out = kernel_client.run_cell(blockline)
             # Extract any error in code
             error = check_errors_in_code_output(outputs, execution_count)

--- a/lib/doconce/jupyter_execution.py
+++ b/lib/doconce/jupyter_execution.py
@@ -425,7 +425,7 @@ def execute_code_block(current_code, current_code_envir, kernel_client, format, 
     # Execute the code
     if kernel_client is None or not kernel_client.is_alive():
         return text_out, execution_count
-    elif postfix == '-out':      # Output cell
+    elif postfix == '-out' or postfix == "-noex": # Output cell, or do not execute
         # Skip executing the code
         outputs = [{'text': current_code}]
     else:
@@ -547,6 +547,8 @@ def get_execute_show(envir):
     elif postfix == '-t':   # Code as text
         execute = False
         show = 'text'
+    elif postfix == '-noex':   # Do not execute (but show it formatted)
+        execute = False
     # Only execute python
     if not option('execute'):
         execute = False


### PR DESCRIPTION
When using `--execute`, it may sometimes be better to skip executing a cell, especially one with an error, than to execute it and have the error present in the notebook (or add it using `-t`). Use case: provide students with unfinished code, e.g. a fill-in-the-blanks exercise, where the blanks cause errors.