### PR TITLE
Add support for Polish language.

### DIFF
--- a/lib/doconce/globals.py
+++ b/lib/doconce/globals.py
@@ -446,6 +446,47 @@ locale_dict = dict(
         # Quiz
         'question_prefix': 'Pregunta:', # question in multiple-choice quiz
         'choice_prefix': 'Alternativa', # choice in multiple-choice quiz
+        },
+     Polish={
+        'locale': 'pl_PL.UTF-8',
+        'latex package': 'polish',
+        'aspell_dictionary' : 'polish', 
+        'toc': 'Spis treści',
+        'Contents': 'Spis treści',
+        'Figure': 'Rysunek',
+        'Movie': 'Film',
+        'list of': 'Lista',
+        'and': 'i',
+        'Exercise': 'Ćwiczenie',
+        'Project': 'Projekt',
+        'Problem': 'Problem',
+        'Example': 'Przykład',
+        'Projects': 'Projekty',
+        'Problems': 'Problemy',
+        'Examples': 'Przykłady',
+        'Preface': 'Wstęp',
+        'Abstract': 'Streszczenie',
+        'Summary': 'Podsumowanie',
+        # Admons
+        'summary': 'podsumowanie',
+        'hint': 'podpowiedź',
+        'question': 'pytanie',
+        'notice': 'uwaga',
+        'warning': 'uwaga!',
+        # box, quote are silent wrt title
+        'remarks': 'uwagi', # In exercises
+        # Exercise headings
+        'Solution': 'Rozwiązanie',
+        'Answer': 'Odpowiedź',
+        'Hint': 'Podpowiedź',
+        # At the end (in Sphinx)
+        'index': 'Indeks',
+        # References
+        'Filename': 'Plik',
+        'Filenames': 'Pliki',
+        # Quiz
+        'question_prefix': 'Pytanie:', # question in multiple-choice quiz
+        'choice_prefix': 'Pytanie',      # choice in multiple-choice quiz
         }
     )
 # Let English be an alias for American
@@ -555,7 +596,7 @@ _registered_command_line_options = [
     ('--no_abort', 'Do not abort the execution if syntax errors are found.'),
     ('--verbose=', 'Write progress of intermediate steps if they take longer than X seconds. 0: X=15 (default); '
                     '1: X=5; 2: X=0'),
-    ('--language=', 'Native language to be used: English (default), Norwegian, German, French, Basque, Arabic, Italian'),
+    ('--language=', 'Native language to be used: English (default), Norwegian, German, French, Basque, Arabic, Italian, Polish'),
     ('--preprocess_include_subst', 'Turns on variable substitutions in # #include paths when running Preprocess: '
                     'preprocess -i -DMYDIR=rn1 will lead to the string "MYDIR" being replaced '
                     'by the value "rn1" in # #include "..." statements.'),


### PR DESCRIPTION
OK. New branch -> `polishLocale` with changes introduced in `globals.py` is ready to merge.
Few remarks:
 - I'm not fully satisfied because during the work it turned out that changes in `globals.py` are not enough to make doconce _fully_ localized.
 - I have prepared a test document and it occured that some names are not translated properly with just `globals.py` localization. For example, words like "Question" "Answer" "Solution" from `!bquiz !equiz` are still in English when processed to pdflatex format. 
   What is more, the plural form of "exercise" or "problem" in the lists of exercises or problems is created in English manner, by adding "s" to language-specific translation of these words. This problem concerns also Norwegian locale (I haven't checked other languages, however I believe this bug is common for all of them), i.e. so we obtain "List of Oppgaves and Problems", while, as I suspect, there should be "Liste over Oppgaver og Problemer".  I compile the document like this:

    `doconce format pdflatex  filename.do.txt --no_ampersand_quote --allow_refs_to_external_docs --language=Norwegian`
    `doconce ptex2tex filename.p.tex`
`pdflatex filename.tex`
`pdflatex filename.tex`

    Is there any other flag needed or is it a bug?
 
 - After some time I discovered that in 'doconce_doc/src/locale/' there are hidden demo files that can be used for testing language localizations. Basing on English stencil I wrote Polish.do.txt document and tested localization with it. In this case all the words are correctly translated, however these documents do not contain problematic keywords mentioned above (quizzes or list of exercises). 
   I could push Polish.do.txt to the repository but another problem arises. The directory 'doconce/doc/src/locale' cloned from https://github.com/doconce/doconce is empty. How can I pull it from GitHub?