### PR TITLE
Fix warning about `\s`

### DIFF
--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -2777,7 +2777,7 @@ for _admon in globals.admons:
              '            block = re.sub(pygments_pattern, r\'"background: %%s">\' %%\n'
              '                           admon_css_vars[html_admon_style][\'background\'], block)\n'
              '        # Strip off <p> at the end of block to reduce space below the text\n'
-             "        block = re.sub(\'(<p>\s*)+$\', '', block)\n"
+             "        block = re.sub(r\'(<p>\\s*)+$\', '', block)\n"
              '        # Need a <p> after the title to ensure some space before the text\n'
              '        alert = """<div class="alert alert-block alert-%(_admon)s alert-text-%%s">\n'
              '<b>%%s</b>\n'


### PR DESCRIPTION
According to GLM-5.2:

```
Root cause: html.py:2716 builds a string _text and exec(_text) runs it at html.py:2845. This happens inside for _admon in globals.admons (5 admons → 5 warnings). Line 65 of _text is:

block = re.sub('(<p>\s*)+$', '', block)
The '(<p>\s*)+$' is a non-raw string containing \s → invalid escape sequence warning on Python 3.12+.

Fix: make the regex a raw string. On line 2780, the outer string literal currently is:

              "        block = re.sub\'(<p>\s*)+$\', '', block)\n"

Change it to (add r before the opening quote, and double the backslash in \s):

              "        block = re.sub(r\'(<p>\\s*)+$\', '', block)\n"

This makes the exec'd code become re.sub(r'(<p>\s*)+$', ...) — a raw string, no warning. The \\s in the outer literal produces \s in the exec'd code, and the outer literal itself no longer contains a bare \s so it won't warn either.
```